### PR TITLE
cmd/gogrep: several improvements

### DIFF
--- a/cmd/gogrep/filters.go
+++ b/cmd/gogrep/filters.go
@@ -36,6 +36,7 @@ func (b bool3) Eq(v bool) bool {
 
 type filterHints struct {
 	autogenCond bool3
+	testCond    bool3
 }
 
 const (

--- a/cmd/gogrep/go.mod
+++ b/cmd/gogrep/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/google/pprof v0.0.0-20211214055906-6f57359322fd
-	github.com/quasilyte/gogrep v0.0.0-20211222142514-47561ea9892a
+	github.com/quasilyte/gogrep v0.0.0-20220102211148-b1ef2ec3d91c
 	github.com/quasilyte/perf-heatmap v0.0.0-20211220153856-7361377975b8
 )
 

--- a/cmd/gogrep/go.sum
+++ b/cmd/gogrep/go.sum
@@ -13,6 +13,8 @@ github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8I
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/quasilyte/gogrep v0.0.0-20211222142514-47561ea9892a h1:WX7f23lL4qeJ4xdtYJb3626N++7uwdGJt5r+BYS4Yow=
 github.com/quasilyte/gogrep v0.0.0-20211222142514-47561ea9892a/go.mod h1:cOIDw+gi1CMpN7VMVdiMUadtrZau1JPspiuxNmvCruU=
+github.com/quasilyte/gogrep v0.0.0-20220102211148-b1ef2ec3d91c h1:eOnLZQFtiqhle+zd6F39v9afJUXoTIVCSjPc2CUC07c=
+github.com/quasilyte/gogrep v0.0.0-20220102211148-b1ef2ec3d91c/go.mod h1:wSEyW6O61xRV6zb6My3HxrQ5/8ke7NE2OayqCHa3xRM=
 github.com/quasilyte/perf-heatmap v0.0.0-20211220115704-5477e07beb6c/go.mod h1:mPJZP5qrgK90IzVVdmPOOJhTXyy65WoldUR1QPeh6AU=
 github.com/quasilyte/perf-heatmap v0.0.0-20211220153856-7361377975b8 h1:XTVqxdjLyMjPMSOaHFsjIqeu1EeUensbK97c2I29In8=
 github.com/quasilyte/perf-heatmap v0.0.0-20211220153856-7361377975b8/go.mod h1:mPJZP5qrgK90IzVVdmPOOJhTXyy65WoldUR1QPeh6AU=

--- a/cmd/gogrep/worker.go
+++ b/cmd/gogrep/worker.go
@@ -60,6 +60,13 @@ func (w *worker) grepFile(filename string) (int, error) {
 		}
 	}
 
+	if w.filterHints.testCond != bool3unset {
+		isTest := strings.HasSuffix(filename, "_test.go")
+		if !w.filterHints.testCond.Eq(isTest) {
+			return 0, nil
+		}
+	}
+
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return 0, fmt.Errorf("read file: %v", err)


### PR DESCRIPTION
* Added `file.IsTest()` filter
* Added `{{replace s old new}}` template func for `--format`
* updated gogrep lib version