### PR TITLE
add support for standalone range clauses

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -127,6 +127,8 @@ func (c *compiler) compileNode(n ast.Node) {
 		c.compileDeclSlice(n)
 	case ExprSlice:
 		c.compileExprSlice(n)
+	case *rangeClause:
+		c.compileRangeClause(n)
 	default:
 		panic(c.errorf(n, "compileNode: unexpected %T", n))
 	}
@@ -1125,6 +1127,11 @@ func (c *compiler) compileExprSlice(exprs ExprSlice) {
 		c.compileExpr(n)
 	}
 	c.emitInstOp(opEnd)
+}
+
+func (c *compiler) compileRangeClause(clause *rangeClause) {
+	c.emitInstOp(opRangeClause)
+	c.compileExpr(clause.X)
 }
 
 func pickOp(cond bool, ifTrue, ifFalse operation) operation {

--- a/compile_test.go
+++ b/compile_test.go
@@ -440,6 +440,12 @@ func TestCompileWildcard(t *testing.T) {
 			` • Ident importFoo`,
 			` • SimpleArgList 0`,
 		},
+
+		`range ($_)`: {
+			`RangeClause`,
+			` • ParenExpr`,
+			` •  • Node`,
+		},
 	})
 
 	for i := range tests {

--- a/gen_operations.go
+++ b/gen_operations.go
@@ -150,6 +150,7 @@ var opPrototypes = []operationProto{
 	{name: "RangeStmt", tag: "RangeStmt", args: "x block", example: "for range x {}"},
 	{name: "RangeKeyStmt", tag: "RangeStmt", args: "key x block", value: "token.Token | ':=' or '='", example: "for key := range x {}"},
 	{name: "RangeKeyValueStmt", tag: "RangeStmt", args: "key value x block", value: "token.Token | ':=' or '='", example: "for key, value := range x {}"},
+	{name: "RangeClause", tag: "RangeStmt", args: "x", example: "range x"},
 
 	{name: "FieldList", args: "fields..."},
 	{name: "UnnamedField", args: "typ", example: "type"},

--- a/match.go
+++ b/match.go
@@ -433,6 +433,9 @@ func (m *matcher) matchNodeWithInst(state *MatcherState, inst instruction, n ast
 		n, ok := n.(*ast.RangeStmt)
 		return ok && n.Key != nil && n.Value != nil && token.Token(inst.value) == n.Tok &&
 			m.matchNode(state, n.Key) && m.matchNode(state, n.Value) && m.matchNode(state, n.X) && m.matchNode(state, n.Body)
+	case opRangeClause:
+		n, ok := n.(*ast.RangeStmt)
+		return ok && m.matchNode(state, n.X)
 
 	case opForStmt:
 		n, ok := n.(*ast.ForStmt)

--- a/match_test.go
+++ b/match_test.go
@@ -24,6 +24,12 @@ func TestMatchCapture(t *testing.T) {
 		{`import $i`, `package p; import ("fmt"; "strings")`, `i:"fmt"; "strings"`},
 		{`import $imports`, `package p; import ("fmt"; "strings")`, `imports:"fmt"; "strings"`},
 		{`import $imports`, `package p; import (crand "crypto/rand"; "strings")`, `imports:crand "crypto/rand"; "strings"`},
+
+		{
+			`range $x`,
+			`package p; func _() { for i, x := range data[0] { println(i, x) } }`,
+			`x:data[0]`,
+		},
 	}
 
 	for i := range tests {
@@ -810,6 +816,16 @@ func TestMatch(t *testing.T) {
 		// {`for $*x {}; for $*x {}`, 0, `{ for range xs {}; for range ys {} }`},
 		// {`for $*x {}; for $*x {}`, 1, `{ for a(); b(); {}; for a(); b(); {} }`},
 		// {`for $*x {}; for $*x {}`, 0, `{ for a(); b(); {}; for a(); b(); c() {} }`},
+
+		// Range clause.
+		{`range xs`, 1, `for i := range xs {}`},
+		{`range xs`, 1, `for i := range xs { f(i) }`},
+		{`range $x`, 1, `for i := range x { f(i) }`},
+		{`range $x`, 1, `for i := range y { f(i) }`},
+		{`range $x`, 2, `for _, xs := range a { for _, x := range xs { println(x) } }`},
+		{`range (xs)`, 1, `for i := range (xs) {}`},
+		{`range xs`, 0, `for i := range ys { f(i) }`},
+		{`range (xs)`, 0, `for i := range xs {}`},
 
 		// Mixing expr and stmt lists.
 		{`$x, $y`, 0, `{ 1; 2 }`},

--- a/operation_string.go
+++ b/operation_string.go
@@ -106,33 +106,34 @@ func _() {
 	_ = x[opRangeStmt-95]
 	_ = x[opRangeKeyStmt-96]
 	_ = x[opRangeKeyValueStmt-97]
-	_ = x[opFieldList-98]
-	_ = x[opUnnamedField-99]
-	_ = x[opSimpleField-100]
-	_ = x[opField-101]
-	_ = x[opMultiField-102]
-	_ = x[opValueSpec-103]
-	_ = x[opValueInitSpec-104]
-	_ = x[opTypedValueInitSpec-105]
-	_ = x[opTypedValueSpec-106]
-	_ = x[opTypeSpec-107]
-	_ = x[opTypeAliasSpec-108]
-	_ = x[opFuncDecl-109]
-	_ = x[opMethodDecl-110]
-	_ = x[opFuncProtoDecl-111]
-	_ = x[opMethodProtoDecl-112]
-	_ = x[opDeclStmt-113]
-	_ = x[opConstDecl-114]
-	_ = x[opVarDecl-115]
-	_ = x[opTypeDecl-116]
-	_ = x[opAnyImportDecl-117]
-	_ = x[opImportDecl-118]
-	_ = x[opEmptyPackage-119]
+	_ = x[opRangeClause-98]
+	_ = x[opFieldList-99]
+	_ = x[opUnnamedField-100]
+	_ = x[opSimpleField-101]
+	_ = x[opField-102]
+	_ = x[opMultiField-103]
+	_ = x[opValueSpec-104]
+	_ = x[opValueInitSpec-105]
+	_ = x[opTypedValueInitSpec-106]
+	_ = x[opTypedValueSpec-107]
+	_ = x[opTypeSpec-108]
+	_ = x[opTypeAliasSpec-109]
+	_ = x[opFuncDecl-110]
+	_ = x[opMethodDecl-111]
+	_ = x[opFuncProtoDecl-112]
+	_ = x[opMethodProtoDecl-113]
+	_ = x[opDeclStmt-114]
+	_ = x[opConstDecl-115]
+	_ = x[opVarDecl-116]
+	_ = x[opTypeDecl-117]
+	_ = x[opAnyImportDecl-118]
+	_ = x[opImportDecl-119]
+	_ = x[opEmptyPackage-120]
 }
 
-const _operation_name = "InvalidNodeNamedNodeNodeSeqNamedNodeSeqOptNodeNamedOptNodeFieldNodeNamedFieldNodeMultiStmtMultiExprMultiDeclEndBasicLitStrictIntLitStrictFloatLitStrictCharLitStrictStringLitStrictComplexLitIdentPkgIndexExprSliceExprSliceFromExprSliceToExprSliceFromToExprSliceToCapExprSliceFromToCapExprFuncLitCompositeLitTypedCompositeLitSimpleSelectorExprSelectorExprTypeAssertExprTypeSwitchAssertExprStructTypeInterfaceTypeVoidFuncTypeFuncTypeArrayTypeSliceTypeMapTypeChanTypeKeyValueExprEllipsisTypedEllipsisStarExprUnaryExprBinaryExprParenExprArgListSimpleArgListVariadicCallExprNonVariadicCallExprCallExprAssignStmtMultiAssignStmtBranchStmtSimpleLabeledBranchStmtLabeledBranchStmtSimpleLabeledStmtLabeledStmtBlockStmtExprStmtGoStmtDeferStmtSendStmtEmptyStmtIncDecStmtReturnStmtIfStmtIfInitStmtIfElseStmtIfInitElseStmtIfNamedOptStmtIfNamedOptElseStmtSwitchStmtSwitchTagStmtSwitchInitStmtSwitchInitTagStmtSelectStmtTypeSwitchStmtTypeSwitchInitStmtCaseClauseDefaultCaseClauseCommClauseDefaultCommClauseForStmtForPostStmtForCondStmtForCondPostStmtForInitStmtForInitPostStmtForInitCondStmtForInitCondPostStmtRangeStmtRangeKeyStmtRangeKeyValueStmtFieldListUnnamedFieldSimpleFieldFieldMultiFieldValueSpecValueInitSpecTypedValueInitSpecTypedValueSpecTypeSpecTypeAliasSpecFuncDeclMethodDeclFuncProtoDeclMethodProtoDeclDeclStmtConstDeclVarDeclTypeDeclAnyImportDeclImportDeclEmptyPackage"
+const _operation_name = "InvalidNodeNamedNodeNodeSeqNamedNodeSeqOptNodeNamedOptNodeFieldNodeNamedFieldNodeMultiStmtMultiExprMultiDeclEndBasicLitStrictIntLitStrictFloatLitStrictCharLitStrictStringLitStrictComplexLitIdentPkgIndexExprSliceExprSliceFromExprSliceToExprSliceFromToExprSliceToCapExprSliceFromToCapExprFuncLitCompositeLitTypedCompositeLitSimpleSelectorExprSelectorExprTypeAssertExprTypeSwitchAssertExprStructTypeInterfaceTypeVoidFuncTypeFuncTypeArrayTypeSliceTypeMapTypeChanTypeKeyValueExprEllipsisTypedEllipsisStarExprUnaryExprBinaryExprParenExprArgListSimpleArgListVariadicCallExprNonVariadicCallExprCallExprAssignStmtMultiAssignStmtBranchStmtSimpleLabeledBranchStmtLabeledBranchStmtSimpleLabeledStmtLabeledStmtBlockStmtExprStmtGoStmtDeferStmtSendStmtEmptyStmtIncDecStmtReturnStmtIfStmtIfInitStmtIfElseStmtIfInitElseStmtIfNamedOptStmtIfNamedOptElseStmtSwitchStmtSwitchTagStmtSwitchInitStmtSwitchInitTagStmtSelectStmtTypeSwitchStmtTypeSwitchInitStmtCaseClauseDefaultCaseClauseCommClauseDefaultCommClauseForStmtForPostStmtForCondStmtForCondPostStmtForInitStmtForInitPostStmtForInitCondStmtForInitCondPostStmtRangeStmtRangeKeyStmtRangeKeyValueStmtRangeClauseFieldListUnnamedFieldSimpleFieldFieldMultiFieldValueSpecValueInitSpecTypedValueInitSpecTypedValueSpecTypeSpecTypeAliasSpecFuncDeclMethodDeclFuncProtoDeclMethodProtoDeclDeclStmtConstDeclVarDeclTypeDeclAnyImportDeclImportDeclEmptyPackage"
 
-var _operation_index = [...]uint16{0, 7, 11, 20, 27, 39, 46, 58, 67, 81, 90, 99, 108, 111, 119, 131, 145, 158, 173, 189, 194, 197, 206, 215, 228, 239, 254, 268, 286, 293, 305, 322, 340, 352, 366, 386, 396, 409, 421, 429, 438, 447, 454, 462, 474, 482, 495, 503, 512, 522, 531, 538, 551, 567, 586, 594, 604, 619, 629, 652, 669, 686, 697, 706, 714, 720, 729, 737, 746, 756, 766, 772, 782, 792, 806, 820, 838, 848, 861, 875, 892, 902, 916, 934, 944, 961, 971, 988, 995, 1006, 1017, 1032, 1043, 1058, 1073, 1092, 1101, 1113, 1130, 1139, 1151, 1162, 1167, 1177, 1186, 1199, 1217, 1231, 1239, 1252, 1260, 1270, 1283, 1298, 1306, 1315, 1322, 1330, 1343, 1353, 1365}
+var _operation_index = [...]uint16{0, 7, 11, 20, 27, 39, 46, 58, 67, 81, 90, 99, 108, 111, 119, 131, 145, 158, 173, 189, 194, 197, 206, 215, 228, 239, 254, 268, 286, 293, 305, 322, 340, 352, 366, 386, 396, 409, 421, 429, 438, 447, 454, 462, 474, 482, 495, 503, 512, 522, 531, 538, 551, 567, 586, 594, 604, 619, 629, 652, 669, 686, 697, 706, 714, 720, 729, 737, 746, 756, 766, 772, 782, 792, 806, 820, 838, 848, 861, 875, 892, 902, 916, 934, 944, 961, 971, 988, 995, 1006, 1017, 1032, 1043, 1058, 1073, 1092, 1101, 1113, 1130, 1141, 1150, 1162, 1173, 1178, 1188, 1197, 1210, 1228, 1242, 1250, 1263, 1271, 1281, 1294, 1309, 1317, 1326, 1333, 1341, 1354, 1364, 1376}
 
 func (i operation) String() string {
 	if i >= operation(len(_operation_index)-1) {

--- a/operations.gen.go
+++ b/operations.gen.go
@@ -451,102 +451,107 @@ const (
 	// Value: token.Token | ':=' or '='
 	opRangeKeyValueStmt operation = 97
 
+	// Tag: RangeStmt
+	// Args: x
+	// Example: range x
+	opRangeClause operation = 98
+
 	// Tag: Unknown
 	// Args: fields...
-	opFieldList operation = 98
+	opFieldList operation = 99
 
 	// Tag: Unknown
 	// Args: typ
 	// Example: type
-	opUnnamedField operation = 99
+	opUnnamedField operation = 100
 
 	// Tag: Unknown
 	// Args: typ
 	// Example: name type
 	// ValueIndex: strings | field name
-	opSimpleField operation = 100
+	opSimpleField operation = 101
 
 	// Tag: Unknown
 	// Args: name typ
 	// Example: $name type
-	opField operation = 101
+	opField operation = 102
 
 	// Tag: Unknown
 	// Args: names... typ
 	// Example: name1, name2 type
-	opMultiField operation = 102
+	opMultiField operation = 103
 
 	// Tag: ValueSpec
 	// Args: value
-	opValueSpec operation = 103
+	opValueSpec operation = 104
 
 	// Tag: ValueSpec
 	// Args: lhs... rhs...
 	// Example: lhs = rhs
-	opValueInitSpec operation = 104
+	opValueInitSpec operation = 105
 
 	// Tag: ValueSpec
 	// Args: lhs... type rhs...
 	// Example: lhs typ = rhs
-	opTypedValueInitSpec operation = 105
+	opTypedValueInitSpec operation = 106
 
 	// Tag: ValueSpec
 	// Args: lhs... type
 	// Example: lhs typ
-	opTypedValueSpec operation = 106
+	opTypedValueSpec operation = 107
 
 	// Tag: TypeSpec
 	// Args: name type
 	// Example: name type
-	opTypeSpec operation = 107
+	opTypeSpec operation = 108
 
 	// Tag: TypeSpec
 	// Args: name type
 	// Example: name = type
-	opTypeAliasSpec operation = 108
+	opTypeAliasSpec operation = 109
 
 	// Tag: FuncDecl
 	// Args: name type block
-	opFuncDecl operation = 109
+	opFuncDecl operation = 110
 
 	// Tag: FuncDecl
 	// Args: recv name type block
-	opMethodDecl operation = 110
+	opMethodDecl operation = 111
 
 	// Tag: FuncDecl
 	// Args: name type
-	opFuncProtoDecl operation = 111
+	opFuncProtoDecl operation = 112
 
 	// Tag: FuncDecl
 	// Args: recv name type
-	opMethodProtoDecl operation = 112
+	opMethodProtoDecl operation = 113
 
 	// Tag: DeclStmt
 	// Args: decl
-	opDeclStmt operation = 113
+	opDeclStmt operation = 114
 
 	// Tag: GenDecl
 	// Args: valuespecs...
-	opConstDecl operation = 114
+	opConstDecl operation = 115
 
 	// Tag: GenDecl
 	// Args: valuespecs...
-	opVarDecl operation = 115
+	opVarDecl operation = 116
 
 	// Tag: GenDecl
 	// Args: typespecs...
-	opTypeDecl operation = 116
+	opTypeDecl operation = 117
 
 	// Tag: GenDecl
-	opAnyImportDecl operation = 117
+	opAnyImportDecl operation = 118
 
 	// Tag: GenDecl
 	// Args: importspecs...
-	opImportDecl operation = 118
+	opImportDecl operation = 119
 
 	// Tag: File
 	// Args: name
-	opEmptyPackage operation = 119
+	opEmptyPackage operation = 120
 )
 
 type operationInfo struct {
@@ -1333,6 +1338,14 @@ var operationInfoTable = [256]operationInfo{
 		Tag:            nodetag.RangeStmt,
 		NumArgs:        4,
 		ValueKind:      tokenValue,
+		ExtraValueKind: emptyValue,
+		VariadicMap:    0, // 0
+		SliceIndex:     -1,
+	},
+	opRangeClause: {
+		Tag:            nodetag.RangeStmt,
+		NumArgs:        1,
+		ValueKind:      emptyValue,
 		ExtraValueKind: emptyValue,
 		VariadicMap:    0, // 0
 		SliceIndex:     -1,

--- a/parse.go
+++ b/parse.go
@@ -46,7 +46,7 @@ func parseExpr(fset *token.FileSet, expr string) (ast.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	node, _, err := parseDetectingNode(fset, exprStr)
+	node, err := parseDetectingNode(fset, exprStr)
 	if err != nil {
 		err = subPosOffsets(err, offs...)
 		return nil, fmt.Errorf("cannot parse expr: %v", err)
@@ -128,14 +128,22 @@ func parseType(fset *token.FileSet, src string) (ast.Expr, *ast.File, error) {
 // one of: *ast.File, ast.Decl, ast.Expr, ast.Stmt, *ast.ValueSpec.
 // It also returns the *ast.File used for the parsing, so that the returned node
 // can be easily type-checked.
-func parseDetectingNode(fset *token.FileSet, src string) (ast.Node, *ast.File, error) {
+func parseDetectingNode(fset *token.FileSet, src string) (ast.Node, error) {
 	file := fset.AddFile("", fset.Base(), len(src))
 	scan := scanner.Scanner{}
 	scan.Init(file, []byte(src), nil, 0)
 	if _, tok, _ := scan.Scan(); tok == token.EOF {
-		return nil, nil, fmt.Errorf("empty source code")
+		return nil, fmt.Errorf("empty source code")
 	}
 	var mainErr error
+
+	// Some adhoc patterns first.
+	if strings.HasPrefix(src, "range ") {
+		e, err := parser.ParseExpr(src[len("range "):])
+		if err == nil && noBadNodes(e) {
+			return &rangeClause{X: e}, nil
+		}
+	}
 
 	// try as a block; otherwise blocks might be mistaken for composite
 	// literals further below
@@ -144,7 +152,7 @@ func parseDetectingNode(fset *token.FileSet, src string) (ast.Node, *ast.File, e
 		bl := f.Decls[0].(*ast.FuncDecl).Body
 		if len(bl.List) == 1 {
 			ifs := bl.List[0].(*ast.IfStmt)
-			return ifs.Body, f, nil
+			return ifs.Body, nil
 		}
 	}
 
@@ -154,9 +162,9 @@ func parseDetectingNode(fset *token.FileSet, src string) (ast.Node, *ast.File, e
 		vs := f.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec)
 		cl := vs.Values[0].(*ast.CompositeLit)
 		if len(cl.Elts) == 1 {
-			return cl.Elts[0], f, nil
+			return cl.Elts[0], nil
 		}
-		return ExprSlice(cl.Elts), f, nil
+		return ExprSlice(cl.Elts), nil
 	}
 
 	// then try as statements
@@ -165,9 +173,9 @@ func parseDetectingNode(fset *token.FileSet, src string) (ast.Node, *ast.File, e
 	if err == nil && noBadNodes(f) {
 		bl := f.Decls[0].(*ast.FuncDecl).Body
 		if len(bl.List) == 1 {
-			return bl.List[0], f, nil
+			return bl.List[0], nil
 		}
-		return stmtSlice(bl.List), f, nil
+		return stmtSlice(bl.List), nil
 	}
 	// Statements is what covers most cases, so it will give
 	// the best overall error message. Show positions
@@ -179,19 +187,19 @@ func parseDetectingNode(fset *token.FileSet, src string) (ast.Node, *ast.File, e
 	asDecl := execTmpl(tmplDecl, src)
 	if f, err := parser.ParseFile(fset, "", asDecl, 0); err == nil && noBadNodes(f) {
 		if len(f.Decls) == 1 {
-			return f.Decls[0], f, nil
+			return f.Decls[0], nil
 		}
-		return declSlice(f.Decls), f, nil
+		return declSlice(f.Decls), nil
 	}
 
 	// try as a whole file
 	if f, err := parser.ParseFile(fset, "", src, 0); err == nil && noBadNodes(f) {
-		return f, f, nil
+		return f, nil
 	}
 
 	// type expressions not yet picked up, for e.g. chans and interfaces
 	if typ, f, err := parseType(fset, src); err == nil && noBadNodes(f) {
-		return typ, f, nil
+		return typ, nil
 	}
 
 	// value specs
@@ -200,11 +208,11 @@ func parseDetectingNode(fset *token.FileSet, src string) (ast.Node, *ast.File, e
 		decl := f.Decls[0].(*ast.GenDecl)
 		if len(decl.Specs) != 0 {
 			vs := f.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec)
-			return vs, f, nil
+			return vs, nil
 		}
 	}
 
-	return nil, nil, mainErr
+	return nil, mainErr
 }
 
 type posOffset struct {
@@ -363,3 +371,10 @@ func decodeWildNode(n ast.Node) varInfo {
 	}
 	return varInfo{}
 }
+
+type rangeClause struct {
+	X ast.Expr
+}
+
+func (*rangeClause) Pos() token.Pos { return 0 }
+func (*rangeClause) End() token.Pos { return 0 }


### PR DESCRIPTION
Examples: `range $x`, `range data[:]`