### PR TITLE
Fix `go install` command-line in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ go get github.com/quasilyte/gogrep
 To get a gogrep command-line tool, install the `cmd/gogrep` Go submodule.
 
 ```bash
-$ go install github.com/quasilyte/cmd/gogrep
+$ go install github.com/quasilyte/gogrep/cmd/gogrep@latest
 ```
 
 See [docs/gogrep_cli.md](_docs/gogrep_cli.md) to learn how to use it.


### PR DESCRIPTION
The go install command line is incorrectly targeting `quasilyte/cmd`. Also I had to add `@latest` for my install.

```
% go install github.com/quasilyte/cmd/gogrep
go: 'go install' requires a version when current directory is not in a module
	Try 'go install github.com/quasilyte/cmd/gogrep@latest' to install the latest version

% go install github.com/quasilyte/cmd/gogrep@latest
go: github.com/quasilyte/cmd/gogrep@latest: module github.com/quasilyte/cmd/gogrep: git ls-remote -q origin in /Users/h10s/go/pkg/mod/cache/vcs/a253bbdbe675c103bdc5b7cc11fdc04c92957a302426b744279f4eca15296a16: exit status 128:
	ERROR: Repository not found.
	fatal: Could not read from remote repository.
	
	Please make sure you have the correct access rights
	and the repository exists.

% go install github.com/quasilyte/gogrep/cmd/gogrep@latest
go: downloading github.com/quasilyte/gogrep v0.0.0-20220828223005-86e4605de09f
go: downloading github.com/quasilyte/gogrep/cmd/gogrep v0.0.0-20220828223005-86e4605de09f
go: downloading github.com/quasilyte/perf-heatmap v0.0.0-20211220153856-7361377975b8
go: downloading github.com/quasilyte/gogrep v0.0.0-20220320171548-f7f5e21cda54
go: downloading github.com/google/pprof v0.0.0-20211214055906-6f57359322fd
```
```